### PR TITLE
Fix user login check

### DIFF
--- a/__tests__/__fixtures__/listCommits.js
+++ b/__tests__/__fixtures__/listCommits.js
@@ -3,25 +3,34 @@ module.exports = [
   {
     commit: {
       author: {
-        name: 'test-user',
+        name: 'Test User',
         email: 'test-user@uber.com',
       },
     },
-  },
-  {
-    commit: {
-      author: {
-        name: 'test-user2',
-        email: 'test-user2@uber.com',
-      },
+    author: {
+      login: 'test-user',
     },
   },
   {
     commit: {
       author: {
-        name: 'test-user3',
+        name: 'Test User2',
+        email: 'test-user2@uber.com',
+      },
+    },
+    author: {
+      login: 'test-user2',
+    },
+  },
+  {
+    commit: {
+      author: {
+        name: 'Test User3',
         email: 'test-user3@uber.com',
       },
+    },
+    author: {
+      login: 'test-user3',
     },
   },
 ];

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -45,8 +45,8 @@ describe('probot-app-merge-pr', () => {
 
     const expectedMessage = `https://github.com/fusionjs/test-repo/pull/1
 
-Co-authored-by: test-user2 <test-user2@uber.com>
-Co-authored-by: test-user3 <test-user3@uber.com>`;
+Co-authored-by: Test User2 <test-user2@uber.com>
+Co-authored-by: Test User3 <test-user3@uber.com>`;
 
     await probot.receive({name: 'issue_comment', payload: fixtures.payload});
     expect(await mergeRequest).toEqual({


### PR DESCRIPTION
The fixtures were set up inaccurately, so PR authors weren't actually being excluded from the merge commit trailers (`if (name !== user.login)` is now `if (item.author.login !== user.login)`).

Also a bit of refactoring