### PR TITLE
Update merge commit title to mimic github's pattern

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -54,14 +54,14 @@ describe('probot-app-merge-pr', () => {
         .reply(200);
     });
 
-    const expectedMessage = `
+    const expectedMessage = `https://github.com/fusionjs/test-repo/pull/1
 
 Co-authored-by: Test User2 <test-user2@uber.com>
 Co-authored-by: Test User3 <test-user3@uber.com>`;
 
     await probot.receive({name: 'issue_comment', payload: fixtures.payload});
     expect(await mergeRequest).toEqual({
-      commit_title: 'Test PR (https://github.com/fusionjs/test-repo/pull/1)',
+      commit_title: 'Test PR (#1)',
       commit_message: expectedMessage,
       merge_method: 'squash',
     });

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -54,14 +54,14 @@ describe('probot-app-merge-pr', () => {
         .reply(200);
     });
 
-    const expectedMessage = `https://github.com/fusionjs/test-repo/pull/1
+    const expectedMessage = `
 
 Co-authored-by: Test User2 <test-user2@uber.com>
 Co-authored-by: Test User3 <test-user3@uber.com>`;
 
     await probot.receive({name: 'issue_comment', payload: fixtures.payload});
     expect(await mergeRequest).toEqual({
-      commit_title: 'Test PR',
+      commit_title: 'Test PR (https://github.com/fusionjs/test-repo/pull/1)',
       commit_message: expectedMessage,
       merge_method: 'squash',
     });

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = robot => {
     }
 
     try {
-      let commit_message = issue.html_url;
+      let commit_message = '';
 
       // add all PR commiters as co-authors
       // https://help.github.com/articles/creating-a-commit-with-multiple-authors/
@@ -69,7 +69,7 @@ module.exports = robot => {
       await github.pullRequests.merge(
         context.repo({
           pull_number: issue.number,
-          commit_title: issue.title,
+          commit_title: `${issue.title} (${issue.html_url})`,
           commit_message,
           merge_method,
         }),

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = robot => {
     }
 
     try {
-      let commit_message = '';
+      let commit_message = issue.html_url;
 
       // add all PR commiters as co-authors
       // https://help.github.com/articles/creating-a-commit-with-multiple-authors/
@@ -69,7 +69,7 @@ module.exports = robot => {
       await github.pullRequests.merge(
         context.repo({
           pull_number: issue.number,
-          commit_title: `${issue.title} (${issue.html_url})`,
+          commit_title: `${issue.title} (#${issue.number})`,
           commit_message,
           merge_method,
         }),


### PR DESCRIPTION
Old:

> [PR Title]
> https://github.com/foo/bar/pull/0

New:

> [PR Title] (#0)
> https://github.com/foo/bar/pull/0

---

~In the UI, github dynamically replaces the full url with the shorthand; e.g. `My title (https://github.com/foo/bar/pull/0)` shows up as `My title (#0)`.~

I'm using this pattern in the sync probot, so just wanted it to be consistent